### PR TITLE
Add theme context for logo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,9 @@
 <div align="center">
   <a href="https://github.com/interactions-py/interactions.py">
-    <img height="200" src="https://user-images.githubusercontent.com/41456914/226150903-e51711d4-22c4-4ce0-ab2a-d163d315bda0.png" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/interactions-py/.github/assets/12771982/c15fe487-871a-4e87-b705-a52317113c9d">
+      <img alt="interactions.py logo" height="200" src="https://user-images.githubusercontent.com/41456914/226150903-e51711d4-22c4-4ce0-ab2a-d163d315bda0.png">
+    </picture>
   </a>
 </div>
 


### PR DESCRIPTION
Github markdown has a few methods for allowing controls of which image is displayed from the colour scheme of the user agent.
I've added an inverted version of the logo and used [this method](https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/) provided by the blog team to display a white logo on a dark theme.
A former method of using `#gh-dark-mode-only` and `#gh-light-mode-only` do exist, are a little tidier, but [they've since been deprecated](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to) for the picture element